### PR TITLE
NonBlockingFetchSql added

### DIFF
--- a/src/Hangfire.SqlServer/SqlServerStorageOptions.cs
+++ b/src/Hangfire.SqlServer/SqlServerStorageOptions.cs
@@ -45,6 +45,7 @@ namespace Hangfire.SqlServer
             TransactionTimeout = TimeSpan.FromMinutes(1);
             DisableGlobalLocks = false;
             UsePageLocksOnDequeue = false;
+            NonBlockingFetchSql = false;
         }
 
         [Obsolete("TransactionIsolationLevel option is deprecated, please set UseRecommendedIsolationLevel instead. Will be removed in 2.0.0.")]
@@ -122,5 +123,6 @@ namespace Hangfire.SqlServer
         public bool UsePageLocksOnDequeue { get; set; }
         public bool UseRecommendedIsolationLevel { get; set; }
         public bool EnableHeavyMigrations { get; set; }
+        public bool NonBlockingFetchSql { get; set;}
     }
 }


### PR DESCRIPTION
Can I recommend something? To use a new storage option :NonBlockingFetchSql
GlobalConfiguration.Configuration.UseSqlServerStorage(dialerConfig.HangfireConnection(),
                new SqlServerStorageOptions
                {
                    CommandBatchMaxTimeout = TimeSpan.FromMinutes(5),
                    SlidingInvisibilityTimeout = TimeSpan.FromMinutes(5),
                    QueuePollInterval = TimeSpan.Zero,
                    UseRecommendedIsolationLevel = true,
                    UsePageLocksOnDequeue = false,
                    DisableGlobalLocks = true,NonBlockingFetchSql=true
                }
                )
In code:

var lockResource = $"{_storage.SchemaName}_FetchLockLock_{String.Join("_", queues.OrderBy(x => x))}";            var isBlocking = Snippetstorage.Options.NonBlockingFetchSql;            var pollingDelayMs = Math.Min(                Math.Max((int)_options.QueuePollInterval.TotalMilliseconds, MinPollingDelayMs),                PollingQuantumMs);